### PR TITLE
start a list of job boards with junior positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ For what that means in detail we created this repo and would like to hear your o
 - [Small Improvements](https://www.small-improvements.com) [Berlin, Germany]
 - [ Insert your company here!! ]
 
+### Job boards with junior positions:
+
+- [careerin.tech](https://careerin.tech/jobs?title=junior)
 
 ---
 PRs for the README are welcome as well.


### PR DESCRIPTION
I'm currently working on a job board for the Berlin tech world. Maybe worth to add?

Do you think a job board should highlight junior positions in a specific way? Any ideas how?